### PR TITLE
Change logic to determine viewer dimensions to be based on width.

### DIFF
--- a/src/js/main.js
+++ b/src/js/main.js
@@ -69,32 +69,20 @@ papaya.Container.prototype.getViewerDimensions = function () {
         parentWidth = window.innerWidth;
     }
 
-    if (parentHeight < PAPAYA_MINIMUM_SIZE) {
-        parentHeight = PAPAYA_MINIMUM_SIZE;
-
-        if (this.kioskMode) {
-            this.containerHtml.parent().height(PAPAYA_MINIMUM_SIZE * 0.8);
-        } else {
-            this.containerHtml.parent().height(PAPAYA_MINIMUM_SIZE * 0.9);
-        }
-    } else if (!this.nestedViewer) {
+    if (!this.nestedViewer) {
         this.containerHtml.parent().height("100%");
     }
 
-    if (parentWidth < PAPAYA_MINIMUM_SIZE) {
-        parentWidth = PAPAYA_MINIMUM_SIZE;
-        this.containerHtml.parent().width(PAPAYA_MINIMUM_SIZE);
-    } else if (!this.nestedViewer) {
+    if (!this.nestedViewer) {
         this.containerHtml.parent().width("100%");
     }
 
     ratio = (this.orthogonal ? 1.5 : 1);
-    height = parentHeight - PAPAYA_SECTION_HEIGHT * numAdditionalSections;
-    width = height * ratio;
-
-    if (width > parentWidth) {
-        width = parentWidth - PAPAYA_SPACING * 2;
-        height = Math.ceil(width / ratio);
+    width = parentWidth;
+    height = width / ratio;
+    if (height > window.innerHeight) {
+        height = window.innerHeight;
+        width = height * ratio;
     }
 
     widthPadding = (parentWidth - width) / 2;


### PR DESCRIPTION
This is a demo of what I proposed in gh-13.

Here are two demos. One for the simple case of a nested viewer in a div without a fixed height:

http://studyforrest.org/mod_t1w.html

and one for a viewer in kiosk mode that is loaded on click to replace a <img>

http://studyforrest.org/mod_t2w.html

This seem to work on both desktop big screen and small smartphone screens.
