### PR TITLE
Display "loading data" in empty kiosk mode viewer

### DIFF
--- a/src/js/viewer/viewer.js
+++ b/src/js/viewer/viewer.js
@@ -476,7 +476,11 @@ papaya.viewer.Viewer.prototype.drawEmptyViewer = function () {
     fontSize = 18;
     this.context.font = fontSize + "px Arial";
     locY = this.canvas.height - 22;
-    text = "Drop here or click the File menu";
+    if (this.container.kioskMode) {
+        text = "Loading data...";
+    } else {
+        text = "Drop here or click the File menu";
+    }
     metrics = this.context.measureText(text);
     textWidth = metrics.width;
     this.context.fillText(text, (this.canvas.width / 2) - (textWidth / 2), locY);


### PR DESCRIPTION
The have no file menu in this mode and the default message confuses.
At the same time in kiosk mode there is probably a preconfigured
image that just hasn't loaded yet.
