### PR TITLE
Added support for DICOM image orientation

### DIFF
--- a/lib/daikon.js
+++ b/lib/daikon.js
@@ -17252,7 +17252,13 @@ daikon.Image.prototype.getImagePosition = function () {
     return daikon.Image.getValueSafely(this.getTag(daikon.Tag.TAG_IMAGE_POSITION[0], daikon.Tag.TAG_IMAGE_POSITION[1]));
 };
 
-
+/**
+ * Returns the image axis directions
+ * @return {number[]}
+ */
+daikon.Image.prototype.getImageDirections = function () {
+  return daikon.Image.getValueSafely(this.getTag(daikon.Tag.TAG_IMAGE_ORIENTATION[0], daikon.Tag.TAG_IMAGE_ORIENTATION[1]))
+}
 
 /**
  * Returns the image position value by index.
@@ -17926,9 +17932,9 @@ daikon.Image.prototype.getOrientation = function () {
             }
             if (bigCol === 4) {
                 if (dirCos[bigCol] > 0.0) {
-                    orient += ('-');
-                } else {
                     orient += ('+');
+                } else {
+                    orient += ('-');
                 }
             } else {
                 if (dirCos[bigCol] > 0.0) {
@@ -20115,7 +20121,9 @@ daikon.Siemens.prototype.readItem = function (offset) {
  * @returns {boolean}
  */
 daikon.Siemens.prototype.canRead = function (group, element) {
-    return (group === daikon.Siemens.GROUP_CSA) && ((element === daikon.Siemens.ELEMENT_CSA1) || (element === daikon.Siemens.ELEMENT_CSA2));
+    return false;
+    //Does not work on all SIEMENS files. TODO: fix the specific code
+    //return (group === daikon.Siemens.GROUP_CSA) && ((element === daikon.Siemens.ELEMENT_CSA1) || (element === daikon.Siemens.ELEMENT_CSA2));
 };
 
 
@@ -20455,9 +20463,13 @@ daikon.Tag.getDateStringValue = function (rawData) {
     for (ctr = 0; ctr < stringData.length; ctr += 1) {
         if (dotFormat) {
             parts = stringData[ctr].split('.');
+            if (parts.length == 3) {
             data[ctr] = new Date(daikon.Utils.safeParseInt(parts[0]),
                 daikon.Utils.safeParseInt(parts[1]) - 1,
                 daikon.Utils.safeParseInt(parts[2]));
+            } else { //Badly formed date, use a default
+              data[ctr] = Date(1,1,1);
+            }
         } else if (stringData[ctr].length === 8) {
             data[ctr] = new Date(daikon.Utils.safeParseInt(stringData[ctr].substring(0, 4)),
                 daikon.Utils.safeParseInt(stringData[ctr].substring(4, 6)) - 1,

--- a/src/js/viewer/colortable.js
+++ b/src/js/viewer/colortable.js
@@ -62,6 +62,10 @@ papaya.viewer.ColorTable.TABLE_BLUE2WHITE = {"name": "Blue Overlay", "data": [[0
     [0.95, 0, 1, 1], [1, 1, 1, 1]], "gradation": true};
 papaya.viewer.ColorTable.TABLE_DTI_SPECTRUM = {"name": "Spectrum", "data": [[0, 1, 0, 0], [0.5, 0, 1, 0], [1, 0, 0, 1]],
     "gradation": true};
+papaya.viewer.ColorTable.TABLE_FIRE = {"name": "Fire", "data": [[0, 0, 0, 0], [0.06, 0, 0, 0.36], [0.16, 0.29, 0, 0.75],
+    [0.22, 0.48, 0, 0.89], [0.31, 0.68, 0, 0.6], [0.37, 0.76, 0, 0.36], [0.5, 0.94, 0.31, 0], [0.56, 1, 0.45, 0],
+    [0.81, 1, 0.91, 0], [0.88, 1, 1, 0.38], [1,1,1,1]], "gradation": true};
+    
 
 papaya.viewer.ColorTable.ARROW_ICON = "data:image/gif;base64,R0lGODlhCwARAPfGMf//////zP//mf//Zv//M///AP/M///MzP/Mmf/M" +
     "Zv/MM//MAP+Z//+ZzP+Zmf+ZZv+ZM/+ZAP9m//9mzP9mmf9mZv9mM/9mAP8z//8zzP8zmf8zZv8zM/8zAP8A//8AzP8Amf8AZv8AM/8AAMz//8z/" +
@@ -82,6 +86,7 @@ papaya.viewer.ColorTable.PARAMETRIC_COLOR_TABLES = [papaya.viewer.ColorTable.TAB
     papaya.viewer.ColorTable.TABLE_BLUE2GREEN];
 
 papaya.viewer.ColorTable.OVERLAY_COLOR_TABLES = [
+    papaya.viewer.ColorTable.TABLE_FIRE,
     papaya.viewer.ColorTable.TABLE_RED2WHITE,
     papaya.viewer.ColorTable.TABLE_GREEN2WHITE,
     papaya.viewer.ColorTable.TABLE_BLUE2WHITE
@@ -96,7 +101,8 @@ papaya.viewer.ColorTable.TABLE_ALL = [
     papaya.viewer.ColorTable.TABLE_GOLD,
     papaya.viewer.ColorTable.TABLE_RED2WHITE,
     papaya.viewer.ColorTable.TABLE_GREEN2WHITE,
-    papaya.viewer.ColorTable.TABLE_BLUE2WHITE
+    papaya.viewer.ColorTable.TABLE_BLUE2WHITE,
+    papaya.viewer.ColorTable.TABLE_FIRE
 ];
 
 papaya.viewer.ColorTable.LUT_MIN = 0;

--- a/src/js/viewer/screenslice.js
+++ b/src/js/viewer/screenslice.js
@@ -30,7 +30,7 @@ papaya.viewer.ScreenSlice = papaya.viewer.ScreenSlice || function (vol, dir, wid
     this.screenTransform = [[1, 0, 0], [0, 1, 0], [0, 0, 1]];
     this.zoomTransform = [[1, 0, 0], [0, 1, 0], [0, 0, 1]];
     this.finalTransform = [[1, 0, 0], [0, 1, 0], [0, 0, 1]];
-    this.radiologicalTransform = [[-1, 0, this.xDim], [0, 1, 0], [0, 0, 1]];
+    this.radiologicalTransform = [[1, 0, 0], [0, -1, this.yDim], [0, 0, 1]];
     this.tempTransform = [[1, 0, 0], [0, 1, 0], [0, 0, 1]];
     this.tempTransform2 = [[1, 0, 0], [0, 1, 0], [0, 0, 1]];
     this.screenTransform2 = [[1, 0, 0], [0, 1, 0], [0, 0, 1]];
@@ -709,8 +709,7 @@ papaya.viewer.ScreenSlice.prototype.updateFinalTransform = function () {
 
 
 papaya.viewer.ScreenSlice.prototype.isRadiologicalSensitive = function () {
-    return ((this.sliceDirection === papaya.viewer.ScreenSlice.DIRECTION_AXIAL) ||
-        (this.sliceDirection === papaya.viewer.ScreenSlice.DIRECTION_CORONAL));
+    return (this.sliceDirection === papaya.viewer.ScreenSlice.DIRECTION_AXIAL);
 };
 
 

--- a/src/js/volume/dicom/header-dicom.js
+++ b/src/js/volume/dicom/header-dicom.js
@@ -536,7 +536,9 @@ papaya.volume.dicom.HeaderDICOM.prototype.getOrientationCertainty = function () 
 
 
 papaya.volume.dicom.HeaderDICOM.prototype.getOrigin = function () {
-    return new papaya.core.Coordinate(0, 0, 0);
+    var m = this.getBestTransform();
+    var invm = numeric.inv(m);
+    return new papaya.core.Coordinate(invm[0][3], invm[1][3], invm[2][3]);
 };
 
 
@@ -583,13 +585,25 @@ papaya.volume.dicom.HeaderDICOM.prototype.getImageDescription = function () {
 
 
 papaya.volume.dicom.HeaderDICOM.prototype.getBestTransform = function () {
-    return null;
+    var cosines = this.series.images[0].getImageDirections();
+    var vs = this.getVoxelDimensions();
+    var coord = this.series.images[0].getImagePosition();
+    var cosx = [cosines[0], cosines[1], cosines[2]];
+    var cosy = [cosines[3], cosines[4], cosines[5]];
+    var cosz = [cosx[1] * cosy[2] - cosx[2] * cosy[1],
+                cosx[2] * cosy[0] - cosx[0] * cosy[2],
+                cosx[0] * cosy[1] - cosx[1] * cosy[0]];
+    var m = [ [cosx[0] * vs.colSize, cosy[0] * vs.rowSize, cosz[0] * vs.sliceSize, coord[0]],
+              [cosx[1] * vs.colSize, cosy[1] * vs.rowSize, cosz[1] * vs.sliceSize, coord[1]],
+              [cosx[2] * vs.colSize, cosy[2] * vs.rowSize, cosz[2] * vs.sliceSize, coord[2]],
+              [0,       0,       0,       1] ];
+    return m.clone();
 };
 
 
 
 papaya.volume.dicom.HeaderDICOM.prototype.getBestTransformOrigin = function () {
-    return null;
+    return this.getOrigin();
 };
 
 


### PR DESCRIPTION
Hi,

This patch adds support to read and use the image orientation from DICOM images. I needed that in order to correctly show SPECT/CT images. The affected files are

* daikon.js: added a function to read the direction cosines from DICOM
* header-dicom.js: updated the getOrigin and getBestTransform
* screenslice.js: Updated the radiological transform

Additionally there is a change in daikon.js to disable importing the private fields from Siemens images as it was crashing on my files and a protection against malformed dates. Also a new Fire color table in colortable.js

This is the first time I do a pull request, so please let me know if I am not following the right procedure.