### PR TITLE
fix processParams in Surface from failing if no global params object exists

### DIFF
--- a/src/js/surface/surface.js
+++ b/src/js/surface/surface.js
@@ -206,7 +206,7 @@ papaya.surface.Surface.prototype.readEncodedData = function (name, volume, callb
 
 
 papaya.surface.Surface.prototype.processParams = function (name) {
-    var screenParams = params[name];
+    var screenParams = this.params[name];
     if (screenParams) {
         if (screenParams.color !== undefined) {
             this.solidColor = screenParams.color;


### PR DESCRIPTION
I was using Papaya without declaring a global params object by creating a viewer using `papaya.Container.addViewer()`. When I added a surface to load, it gave an error: "params is undefined" in [the processParams method in surface.js](https://github.com/rii-mango/Papaya/blob/master/src/js/surface/surface.js#L209).

There's a reference made to `params` there, a global variable. `Surface` already has a `params` property and should use that so that it doesn't depend on a global variable existing. I fixed this problem by replacing `params` with `this.params`.