### PR TITLE
Enable scroll wheel even with nested viewers

### DIFF
--- a/src/js/viewer/viewer.js
+++ b/src/js/viewer/viewer.js
@@ -696,9 +696,9 @@ papaya.viewer.Viewer.prototype.finishedLoading = function () {
 
 
 papaya.viewer.Viewer.prototype.addScroll = function () {
-    if (!this.container.nestedViewer) {
+    // if (!this.container.nestedViewer) {
         window.addEventListener(papaya.utilities.PlatformUtils.getSupportedScrollEvent(), this.listenerScroll, false);
-    }
+    // }
 };
 
 
@@ -2842,12 +2842,17 @@ papaya.viewer.Viewer.prototype.isUsingAtlas = function (name) {
 
 papaya.viewer.Viewer.prototype.scrolled = function (e) {
     var scrollSign, isSliceScroll;
-
+/*
     if (this.container.nestedViewer || ((papayaContainers.length > 1) && !this.container.collapsable)) {
         return;
     }
-
+*/
     e = e || window.event;
+
+    //If the scroll event happened outside the canvas don't handle it
+    if(e.target != this.canvas) {
+        return;
+    }
 
     if (e.preventDefault) {
         e.preventDefault();


### PR DESCRIPTION
With these changes the scroll wheel will work even if there are multiple instances of papaya in the same page, whether they are nested or not.

For example:
`<script type="text/javascript">`
`   var params1 = {images: [['test1.nii.gz']]},`
`         params2 = {images: [['test2.nii.gz']]},`
`         params3 = {images: [['test3.nii.gz']]};`
`</script>`
`<div class="container" style="display:flex;flex-flow: row wrap;">`
`   <div style="width:500px;height:500px;">`
`      <div class="papaya" data-params="params1"></div>`
`   </div>`
`   <div style="width:500px;height:500px;">`
`      <div class="papaya" data-params="params2"></div>`
`   </div>`
`   <div style="width:500px;height:500px;">`
`      <div class="papaya" data-params="params3"></div>`
`   </div>`
`</div>`