### PR TITLE
Add parameter noNewFiles. Disallows opening of new files.

### DIFF
--- a/src/js/main.js
+++ b/src/js/main.js
@@ -47,6 +47,7 @@ papaya.Container = papaya.Container || function (containerHtml) {
     this.orthogonalTall = false;
     this.orthogonalDynamic = false;
     this.kioskMode = false;
+    this.noNewFiles = false;
     this.showControls = true;
     this.showControlBar = false;
     this.showImageButtons = true;
@@ -742,6 +743,10 @@ papaya.Container.prototype.readGlobalParams = function() {
         this.showControls = this.params.showControls;
     }
 
+    if (this.params.noNewFiles !== undefined) {  // default is false
+        this.noNewFiles = this.params.noNewFiles;
+    }
+
     if (this.params.showImageButtons !== undefined) {  // default is true
         this.showImageButtons = this.params.showImageButtons;
     }
@@ -810,6 +815,7 @@ papaya.Container.prototype.reset = function () {
     this.orthogonalTall = false;
     this.orthogonalDynamic = false;
     this.kioskMode = false;
+    this.noNewFiles = false;
     this.showControls = true;
     this.showControlBar = false;
     this.fullScreenPadding = true;

--- a/src/js/ui/toolbar.js
+++ b/src/js/ui/toolbar.js
@@ -340,7 +340,11 @@ papaya.ui.Toolbar.prototype.buildToolbar = function () {
         if ((this.container.viewer.screenVolumes.length > 0) && this.container.viewer.screenVolumes[0].rgb) {
             papaya.ui.Toolbar.MENU_DATA.menus[0] = papaya.ui.Toolbar.RGB_FILE_MENU_DATA;
         } else {
-            papaya.ui.Toolbar.MENU_DATA.menus[0] = papaya.ui.Toolbar.FILE_MENU_DATA;
+            if (this.container.noNewFiles) {
+                papaya.ui.Toolbar.MENU_DATA.menus[0] = papaya.ui.Toolbar.RGB_FILE_MENU_DATA;
+            } else {
+                papaya.ui.Toolbar.MENU_DATA.menus[0] = papaya.ui.Toolbar.FILE_MENU_DATA;
+            }
             this.buildOpenMenuItems(papaya.ui.Toolbar.MENU_DATA);
         }
 

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -256,6 +256,11 @@ params["message"] = "Test: orthogonalTall.";
 
 params = initTest();
 params["images"] = ["data/sample_image.nii.gz"];
+params["noNewFiles"] = true;
+params["message"] = "Test: noNewFiles.";
+
+params = initTest();
+params["images"] = ["data/sample_image.nii.gz"];
 params["showControls"] = false;
 params["message"] = "Test: showControls (false).";
 


### PR DESCRIPTION
Implements RGB_FILE_MENU_DATA for "Files" label. "Close All" files only.

  Not sure if you'll find my use case of interest, but thought I'd try a PR just in case.

  I am using Papaya as a file viewer for a custom file repository. I think my users will find it confusing to have a file opener that opens files from their desktop. They will be assuming files come from the custom repository. More worrying is that they may assume that when they load a file that it has been saved to the custom repository.
  However, I'm reluctant to use kioskMode when there is so much nice functionality in the viewer.

  I added a test, but I'm not quite sure how to run the tests, so there is that. :/

Here is a possible update for the Wiki...
```
* `noNewFiles`: If true (defaults false), Add (image) options will be hidden in "File" dropdown.
```