### PR TITLE
Fix artifactual shear seen in oblique MRI scans

### DIFF
--- a/src/js/volume/dicom/header-dicom.js
+++ b/src/js/volume/dicom/header-dicom.js
@@ -614,8 +614,8 @@ papaya.volume.dicom.HeaderDICOM.prototype.getBestTransform = function () {
         var cosz = [cosx[1] * cosy[2] - cosx[2] * cosy[1],
             cosx[2] * cosy[0] - cosx[0] * cosy[2],
             cosx[0] * cosy[1] - cosx[1] * cosy[0]];
-        m = [ [cosx[0] * vs.colSize * -1, cosy[0] * vs.rowSize, cosz[0] * vs.sliceSize, -1 * coord[0]],
-            [cosx[1] * vs.colSize, cosy[1] * vs.rowSize * -1, cosz[1] * vs.sliceSize, -1 * coord[1]],
+        m = [ [cosx[0] * vs.colSize * -1, cosy[0] * vs.rowSize * -1, cosz[0] * vs.sliceSize * -1, -1 * coord[0]],
+            [cosx[1] * vs.colSize * -1, cosy[1] * vs.rowSize * -1, cosz[1] * vs.sliceSize * -1, -1 * coord[1]],
             [cosx[2] * vs.colSize, cosy[2] * vs.rowSize, cosz[2] * vs.sliceSize, coord[2]],
             [0,       0,       0,       1] ];
     }


### PR DESCRIPTION
This fixes a problem in the DICOM-to-NIfTI spatial transform. To illustrate the issue, open a DICOM image where the image angulation is not aligned with the scanner bore. For a concrete example, open the [DICOM image from this repository](https://github.com/open-dicom/siemens_mprage_0) with [papaya](https://papaya.greenant.net) and set to world coordinates to observe an image with substantial shear.

![Screen Shot 2022-04-21 at 11 43 19 AM](https://user-images.githubusercontent.com/8930807/164702301-10f75e42-3e67-4f2c-a906-b6cf48469001.png)

If you open the repositories NIfTI image (converted with dcm2niix) one can observe that the image does not have a shear.

The problem can be traced to [lines 617 and 618 of getBestTransform()](https://github.com/rii-mango/Papaya/blob/782a19341af77a510d674c777b6da46afb8c65f1/src/js/volume/dicom/header-dicom.js#L618) where the -1 is only applied to two of the four components for each row of the matrix, where they should be applied to all four rows.

The -1 value flips the X (left-right) and Y (anterior-posterior) from DICOM to NIfTI [coordinate systems](https://www.nitrc.org/plugins/mwiki/index.php/dcm2nii:MainPage#Spatial_Coordinates). In DICOM X ascends leftwards and Y ascends posteriorly, while teh reverse is true for MNI/Talairach coordinates.

